### PR TITLE
Update postinstall

### DIFF
--- a/installapplications/generatejson_provision_demo.sh
+++ b/installapplications/generatejson_provision_demo.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-COREDIR=$(/usr/bin/dirname $0)
+# Not reliable working when zsh is active
+# COREDIR=$(/usr/bin/dirname $0)
+COREDIR=$( cd "$(dirname "$0")" ; pwd -P )
 JSON="${COREDIR}/demo.json"
 GENERATEJSON="${COREDIR}/generatejson.py"
 PKGSDIR="${COREDIR}/pkgs"

--- a/munkipkg/installapplications/scripts/postinstall
+++ b/munkipkg/installapplications/scripts/postinstall
@@ -22,6 +22,10 @@ launch_daemon_plist_name='com.erikng.installapplications'
 launch_agent_base_path='Library/LaunchAgents/'
 launch_daemon_base_path='Library/LaunchDaemons/'
 
+# If this is not exactly set to this permissions, it can not be loaded
+chmod 600 "$3${launch_agent_base_path}${launch_agent_plist_name}.plist"
+chmod 600 "$3${launch_daemon_base_path}${launch_daemon_plist_name}.plist"
+
 # Load agent if installing to a running system
 if [[ $3 == "/" ]] ; then
   # Fail the install if the admin forgets to change their paths and they don't exist.


### PR DESCRIPTION
CHMODed LaunchDaemonand LaunchAgent because of permission error. Not sure when exactly this occurs but this way it never occured.